### PR TITLE
package unixproxy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,37 +1,43 @@
-on: push
-name: tests
+name: Test
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [main]
+
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Install staticcheck
-      run: pwd && cd .. && go get -v -u honnef.co/go/tools/cmd/staticcheck && cd -
-      shell: bash
-    - name: Install golint
-      run: pwd && cd .. && go get -v -u golang.org/x/lint/golint && cd -
-      shell: bash
-    - name: Update PATH
-      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      shell: bash
-    - name: Checkout code
-      uses: actions/checkout@v1
-    - name: Fmt
-      if: matrix.platform != 'windows-latest' # :(
-      run: "F=$(gofmt -l .) ; if [[ $F ]] ; then echo $F ; exit 1 ; fi"
-      shell: bash
-    - name: Vet
-      run: go vet ./...
-    - name: Staticcheck
-      run: staticcheck ./...
-    - name: Lint
-      run: golint ./...
-    - name: Test
-      run: go test -race ./...
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.x
+
+      - name: Check out repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # default is a pseudo 'merge' commit
+
+      - name: Install tools
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install mvdan.cc/gofumpt@latest
+
+      - name: gofmt
+        run: diff <(gofmt -d . 2>/dev/null) <(printf '')
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: staticcheck
+        run: staticcheck ./...
+
+      - name: gofumpt
+        run: diff <(gofumpt -d -e -l . 2>/dev/null) <(printf '')
+
+      - name: go test
+        run: go test -v ./...

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// package unixtransport allows HTTP client requests to Unix sockets.
+package unixtransport

--- a/example_test.go
+++ b/example_test.go
@@ -23,11 +23,12 @@ func ExampleRegister_custom() {
 		// ...
 	}
 
+	unixtransport.Register(t)
+
 	c := &http.Client{
 		Transport: t,
+		// ...
 	}
-
-	unixtransport.Register(t)
 
 	c.Get("https+unix:///tmp/my.sock")
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,33 @@
+package unixtransport_test
+
+import (
+	"net/http"
+
+	"github.com/peterbourgon/unixtransport"
+)
+
+func ExampleRegister_default() {
+	// Register the "http+unix" and "https+unix" protocols in the default client transport.
+	unixtransport.Register(http.DefaultTransport.(*http.Transport))
+
+	// This will issue a GET request to an HTTP server listening at /tmp/my.sock.
+	// Note the three '/' characters between 'http+unix:' and 'tmp'.
+	http.Get("http+unix:///tmp/my.sock")
+
+	// This shows how to include a request path and query.
+	http.Get("http+unix:///tmp/my.sock:/users/123?q=abc")
+}
+
+func ExampleRegister_custom() {
+	t := &http.Transport{
+		// ...
+	}
+
+	c := &http.Client{
+		Transport: t,
+	}
+
+	unixtransport.Register(t)
+
+	c.Get("https+unix:///tmp/my.sock")
+}

--- a/register.go
+++ b/register.go
@@ -14,7 +14,7 @@ import (
 // requests to Unix domain sockets via the "http+unix" or "https+unix" schemes.
 // Request URLs should have the following form:
 //
-//    https+unix:///path/to/socket:/request/path?query=val&...
+//	https+unix:///path/to/socket:/request/path?query=val&...
 //
 // The registered transport is based on a clone of the provided transport, and
 // so uses the same configuration: timeouts, TLS settings, and so on. Connection

--- a/unixproxy/README.md
+++ b/unixproxy/README.md
@@ -1,10 +1,11 @@
 # package unixproxy
 
-<h3 align="center">:warning: &nbsp; EXPERIMENTAL AND POTENTIALLY INSECURE &nbsp; :warning:</h3>
+> :warning: EXPERIMENTAL AND POTENTIALLY INSECURE
 
 This package provides a reverse proxy to local Unix sockets. The intent is to
 facilitate local development of distributed systems, by creating
-semantically-meaningful addresses for an arbitrary number of local processes.
+semantically-meaningful addresses for an arbitrary number of HTTP servers on
+localhost.
 
 See [package documentation][docs] for details.
 

--- a/unixproxy/README.md
+++ b/unixproxy/README.md
@@ -1,0 +1,11 @@
+# package unixproxy
+
+<h3 align="center">:warning: &nbsp; EXPERIMENTAL AND POTENTIALLY INSECURE &nbsp; :warning:</h3>
+
+This package provides a reverse proxy to local Unix sockets. The intent is to
+facilitate local development of distributed systems, by creating
+semantically-meaningful addresses for an arbitrary number of local processes.
+
+See [package documentation][docs] for details.
+
+[docs]: https://pkg.go.dev/github.com/peterbourgon/unixtransport/unixproxy

--- a/unixproxy/cmd/unixproxy/go.mod
+++ b/unixproxy/cmd/unixproxy/go.mod
@@ -1,0 +1,11 @@
+module unixproxy
+
+go 1.20
+
+replace github.com/peterbourgon/unixtransport => ../../..
+
+require (
+	github.com/oklog/run v1.1.0
+	github.com/peterbourgon/ff/v3 v3.3.0
+	github.com/peterbourgon/unixtransport v0.0.0-00010101000000-000000000000
+)

--- a/unixproxy/cmd/unixproxy/go.mod
+++ b/unixproxy/cmd/unixproxy/go.mod
@@ -2,10 +2,10 @@ module unixproxy
 
 go 1.20
 
-replace github.com/peterbourgon/unixtransport => ../../..
-
 require (
 	github.com/oklog/run v1.1.0
 	github.com/peterbourgon/ff/v3 v3.3.0
 	github.com/peterbourgon/unixtransport v0.0.0-00010101000000-000000000000
 )
+
+replace github.com/peterbourgon/unixtransport => ../../..

--- a/unixproxy/cmd/unixproxy/go.sum
+++ b/unixproxy/cmd/unixproxy/go.sum
@@ -1,0 +1,4 @@
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/peterbourgon/ff/v3 v3.3.0 h1:PaKe7GW8orVFh8Unb5jNHS+JZBwWUMa2se0HM6/BI24=
+github.com/peterbourgon/ff/v3 v3.3.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=

--- a/unixproxy/cmd/unixproxy/main.go
+++ b/unixproxy/cmd/unixproxy/main.go
@@ -41,9 +41,9 @@ func main() {
 func exe(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, args []string) error {
 	fs := flag.NewFlagSet("unixproxy", flag.ContinueOnError)
 	var (
-		proxyAddr   = fs.String("proxy-addr", ":80", "HTTP listen endpoint for reverse proxy server")
-		hostHeader  = fs.String("host-header", "unixproxy.localhost", "Host header where this service is reachable")
-		socketsPath = fs.String("sockets-path", ".", "root path to look for Unix sockets")
+		addrFlag = fs.String("addr", ":80", "HTTP listen endpoint for reverse proxy server")
+		hostFlag = fs.String("host", "unixproxy.localhost", "Host header where this service is reachable")
+		rootFlag = fs.String("root", ".", "root path to look for Unix sockets")
 	)
 	if err := ff.Parse(fs, args); err != nil {
 		return fmt.Errorf("parse flags: %w", err)
@@ -51,20 +51,20 @@ func exe(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, args []
 
 	logger := log.New(stderr, "", 0)
 
-	proxyListener, err := unixproxy.ListenURI(ctx, *proxyAddr)
+	proxyListener, err := unixproxy.ListenURI(ctx, *addrFlag)
 	if err != nil {
 		return fmt.Errorf("listen on proxy addr: %w", err)
 	}
 
 	proxyHandler := &unixproxy.Handler{
-		Host:           *hostHeader,
-		Root:           *socketsPath,
+		Host:           *hostFlag,
+		Root:           *rootFlag,
 		ErrorLogWriter: logger.Writer(),
 	}
 
-	logger.Printf("listening on %s", proxyListener.Addr())
-	logger.Printf("serving host http://%s", *hostHeader)
-	logger.Printf("proxying to sockets in %s", *socketsPath)
+	logger.Printf("proxy listening on %s", proxyListener.Addr())
+	logger.Printf("serving host http://%s", *hostFlag)
+	logger.Printf("sockets root path %s", *rootFlag)
 
 	var g run.Group
 

--- a/unixproxy/cmd/unixproxy/main.go
+++ b/unixproxy/cmd/unixproxy/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"syscall"
+
+	"github.com/oklog/run"
+	"github.com/peterbourgon/ff/v3"
+	"github.com/peterbourgon/unixtransport/unixproxy"
+)
+
+func main() {
+	err := exe(
+		context.Background(),
+		os.Stdin,
+		os.Stdout,
+		os.Stderr,
+		os.Args[1:],
+	)
+	switch {
+	case err == nil:
+		os.Exit(0)
+	case errors.Is(err, flag.ErrHelp):
+		os.Exit(1)
+	case isSignalError(err):
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(0)
+	case err != nil:
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func exe(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, args []string) error {
+	fs := flag.NewFlagSet("unixproxy", flag.ContinueOnError)
+	var (
+		proxyAddr   = fs.String("proxy-addr", ":80", "HTTP listen endpoint for reverse proxy server")
+		hostHeader  = fs.String("host-header", "unixproxy.localhost", "Host header where this service is reachable")
+		socketsPath = fs.String("sockets-path", ".", "root path to look for Unix sockets")
+	)
+	if err := ff.Parse(fs, args); err != nil {
+		return fmt.Errorf("parse flags: %w", err)
+	}
+
+	logger := log.New(stderr, "", 0)
+
+	proxyListener, err := unixproxy.ListenURI(ctx, *proxyAddr)
+	if err != nil {
+		return fmt.Errorf("listen on proxy addr: %w", err)
+	}
+
+	proxyHandler := &unixproxy.Handler{
+		Host:           *hostHeader,
+		Root:           *socketsPath,
+		ErrorLogWriter: logger.Writer(),
+	}
+
+	logger.Printf("listening on %s", proxyListener.Addr())
+	logger.Printf("serving host http://%s", *hostHeader)
+	logger.Printf("proxying to sockets in %s", *socketsPath)
+
+	var g run.Group
+
+	{
+		server := &http.Server{Handler: proxyHandler}
+		g.Add(func() error {
+			return server.Serve(proxyListener)
+		}, func(error) {
+			server.Close()
+		})
+	}
+
+	{
+		g.Add(run.SignalHandler(ctx, syscall.SIGINT, syscall.SIGTERM))
+	}
+
+	return g.Run()
+}
+
+func isSignalError(err error) bool {
+	var sig run.SignalError
+	return errors.As(err, &sig)
+}

--- a/unixproxy/doc.go
+++ b/unixproxy/doc.go
@@ -1,0 +1,20 @@
+// package unixproxy provides an EXPERIMENTAL reverse proxy to Unix sockets.
+//
+// The intent of this package is to facilitate local development of distributed
+// systems, by allowing normal HTTP clients that assume TCP (cURL, browsers,
+// etc.) to address localhost servers via semantically-meaningful subdomains
+// rather than opaque port numbers. The intermediating reverse-proxy works
+// dynamically, without any explicit configuration.
+//
+// [Handler] provides the reverse-proxy logic. See documentation on that type
+// for usage information.
+//
+// Application servers need to be able to listen on Unix sockets. The [ParseURI]
+// and [ListenURI] helpers exist for this purpose. They accept both typical
+// listen addresses e.g. "localhost:8081" or ":8081" as well as e.g.
+// "unix:///tmp/my.sock" as input. Applications can use these helpers to create
+// listeners, and bind HTTP servers to those listeners, rather than using
+// default helpers that assume TCP, like [http.ListenAndServe].
+//
+// cmd/unixproxy is an example program utilizing package unixproxy.
+package unixproxy

--- a/unixproxy/handler.go
+++ b/unixproxy/handler.go
@@ -1,0 +1,190 @@
+package unixproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// Handler is a reverse proxy to Unix sockets on the local filesystem.
+//
+// Requests are mapped to target Unix sockets based on their Host header. Each
+// sub-domain element underneath the configured Host TLD is parsed as a filepath
+// element relative to Root directory. If that resolved filepath is a valid Unix
+// socket, the request is proxied to that socket, via an [http.Client] that
+// utilizes [github.com/peterbourgon/unixtransport].
+//
+// For example, a Handler configured with Host "unixproxy.localhost" and Root
+// "/tmp/abc" would map a request with Host "foo.bar.unixproxy.localhost" to a
+// Unix socket at "/tmp/abc/foo/bar", if it exists.
+type Handler struct {
+	// Host is the top-level domain (TLD) of the Handler, which is expected to
+	// end in ".localhost" as per RFC2606. The system should be configured to
+	// resolve requests to this domain (and all subdomains) to localhost,
+	// typically via an entry in "/etc/hosts".
+	//
+	// Optional. The default value is "unixproxy.localhost".
+	Host string
+
+	// Root is a valid directory on the local filesystem. The handler will look
+	// in this directory tree, recursively, for valid Unix sockets, when
+	// proxying a given request.
+	//
+	// Required.
+	Root string
+
+	// ErrorLogWriter is used as the destination writer for the ErrorLog of the
+	// [http.ReverseProxy] used to proxy individual requests.
+	//
+	// Optional. By default, each [http.ReverseProxy] has a nil ErrorLog.
+	ErrorLogWriter io.Writer
+}
+
+// Domains returns a slice of strings that represent valid Host headers for
+// incoming requests. It computes this slice by walking the directory tree from
+// the Root directory via [filepath.WalkDir], and converting the relative file
+// path of any valid Unix socket to a FQDN underneath the Host TLD. Results are
+// not cached.
+func (h *Handler) Domains() ([]string, error) {
+	var domains []string
+	if err := filepath.WalkDir(h.Root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.Type()&os.ModeSocket == 0 {
+			return nil
+		}
+
+		relpath, err := filepath.Rel(h.Root, path)
+		if err != nil {
+			return err
+		}
+
+		subdomain := strings.Replace(relpath, string(filepath.Separator), ".", -1)
+		domain := strings.Trim(subdomain, ".") + "." + strings.Trim(h.Host, ".")
+		domains = append(domains, domain)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return domains, nil
+}
+
+// ServeHTTP implements http.Handler. If the request Host header is equal to the
+// Host field (i.e. has no subdomains), ServeHTTP will serve a list of valid
+// subdomains. Otherwise, the request will be proxied to a local Unix domain
+// socket based on its subdomain.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/favicon.ico":
+		http.NotFound(w, r)
+	case r.Host == h.Host:
+		h.handleIndex(w, r)
+	default:
+		h.handleProxy(w, r)
+	}
+}
+
+func (h *Handler) handleIndex(w http.ResponseWriter, r *http.Request) {
+	domains, err := h.Domains()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	accept := strings.ToLower(r.Header.Get("accept"))
+	switch {
+	case strings.Contains(accept, "text/html"):
+		var buf bytes.Buffer
+		if err := indexTemplate.Execute(&buf, struct{ Domains []string }{domains}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("content-type", "text/html; charset=utf-8")
+		buf.WriteTo(w)
+
+	case strings.Contains(accept, "application/json"):
+		w.Header().Set("content-type", "application/json; charset=utf-8")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "    ")
+		enc.Encode(domains)
+
+	default:
+		w.Header().Set("content-type", "text/plain; charset=utf-8")
+		for _, s := range domains {
+			fmt.Fprintln(w, s)
+		}
+	}
+}
+
+func (h *Handler) handleProxy(w http.ResponseWriter, r *http.Request) {
+	var (
+		clean    = strings.TrimSuffix(r.Host, h.Host)
+		elements = strings.Split(clean, ".")
+		relative = filepath.Join(elements...)
+		socket   = filepath.Join(h.Root, relative)
+	)
+
+	fi, err := os.Stat(socket) // TODO: sanitize, chroot, etc.
+	if err != nil || fi.Mode()&os.ModeSocket == 0 {
+		http.Error(w, fmt.Sprintf("target socket %s invalid", socket), http.StatusNotFound)
+		return
+	}
+
+	director := func(req *http.Request) {
+		req.URL.Scheme = "http"
+		req.URL.Host = socket
+		req.URL.Path = r.URL.Path
+	}
+
+	var proxyLog *log.Logger
+	if h.ErrorLogWriter != nil {
+		proxyLog = log.New(h.ErrorLogWriter, fmt.Sprintf("unixproxy: %s: ", relative), 0)
+	}
+
+	rp := &httputil.ReverseProxy{
+		Transport: onlyUnixTransport,
+		ErrorLog:  proxyLog,
+		Director:  director,
+	}
+
+	rp.ServeHTTP(w, r)
+}
+
+var onlyUnixTransport = &http.Transport{
+	DialContext: func(ctx context.Context, _, address string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(address)
+		if err == nil {
+			address = host
+		}
+		return (&net.Dialer{}).DialContext(ctx, "unix", address)
+	},
+}
+
+var indexTemplate = template.Must(template.New("").Parse(`
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>unixproxy</title>
+</head>
+<body>
+<ul>
+{{ range .Domains -}}
+<li><a href="//{{.}}">{{.}}</a></li>
+{{ else -}}
+<li>No active sockets found</li>
+{{ end -}}
+</ul>
+`))

--- a/unixproxy/handler.go
+++ b/unixproxy/handler.go
@@ -28,11 +28,13 @@ import (
 // As an example, a Handler configured with Host "unixproxy.localhost" and Root
 // "/tmp/abc" would map a request with Host header "foo.bar.unixproxy.localhost"
 // to a socket at "/tmp/abc/foo/bar".
+//
+// Parameters are evaluated during ServeHTTP.
 type Handler struct {
-	// Host is the base/apex domain of the Handler, which should end in
-	// ".localhost" per RFC2606. The system should be configured to resolve that
-	// domain (and all subdomains) to localhost, typically via an entry in
-	// "/etc/hosts".
+	// Host is the base/apex domain which the Handler expects to receive as part
+	// of all request Host headers. It should end in ".localhost" per RFC2606,
+	// and the system should be configured to resolve that domain (and all
+	// subdomains) to localhost, typically via an entry in "/etc/hosts".
 	//
 	// Optional. The default value is "unixproxy.localhost".
 	Host string

--- a/unixproxy/handler_test.go
+++ b/unixproxy/handler_test.go
@@ -1,0 +1,96 @@
+package unixproxy_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/unixtransport/unixproxy"
+)
+
+func TestHandlerBasic(t *testing.T) {
+	proxy, close := testHandlerServer(t, context.Background())
+	defer close()
+
+	if want, have := strings.Join([]string{
+		"bar.unixproxy.localhost", // lexicographical order from walk
+		"baz.unixproxy.localhost", //
+		"foo.unixproxy.localhost", //
+	}, "\n"), testBasicRequest(t, proxy, "unixproxy.localhost"); want != have {
+		t.Errorf("GET unixproxy.localhost: want %q, have %q", want, have)
+	}
+
+	if want, have := "hello from foo", testBasicRequest(t, proxy, "foo.unixproxy.localhost"); want != have {
+		t.Errorf("GET foo.unixproxy.localhost: want %q, have %q", want, have)
+	}
+
+	if want, have := "hello from bar", testBasicRequest(t, proxy, "bar.unixproxy.localhost"); want != have {
+		t.Errorf("GET bar.unixproxy.localhost: want %q, have %q", want, have)
+	}
+
+	if want, have := "hello from baz", testBasicRequest(t, proxy, "baz.unixproxy.localhost"); want != have {
+		t.Errorf("GET baz.unixproxy.localhost: want %q, have %q", want, have)
+	}
+}
+
+func testHandlerServer(t *testing.T, ctx context.Context) (*httptest.Server, func()) {
+	t.Helper()
+
+	root := t.TempDir()
+
+	var closers []func()
+
+	for _, x := range []string{"foo", "bar", "baz"} {
+		response := fmt.Sprintf("hello from %s", x)
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, response)
+		}))
+
+		listener, err := unixproxy.ListenURI(ctx, "unix://"+root+"/"+x)
+		if err != nil {
+			t.Fatalf("%s: %v", x, err)
+		}
+
+		server.Listener = listener
+		server.Start()
+		closers = append(closers, func() {
+			server.Close()
+			listener.Close()
+		})
+	}
+
+	proxy := httptest.NewServer(&unixproxy.Handler{
+		Host: "unixproxy.localhost",
+		Root: root,
+	})
+
+	close := func() {
+		for _, f := range closers {
+			f()
+		}
+	}
+
+	return proxy, close
+}
+
+func testBasicRequest(t *testing.T, proxy *httptest.Server, host string) string {
+	t.Helper()
+
+	req, _ := http.NewRequest("GET", proxy.URL, nil)
+	req.Host = host
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return strings.TrimSpace(string(body))
+}

--- a/unixproxy/parse.go
+++ b/unixproxy/parse.go
@@ -11,14 +11,14 @@ import (
 // ParseURI parses the given URI to a network and address that can be passed to
 // e.g. [net.Listen].
 //
-// The URI's scheme is interpreted as the network, and the host (and port) are
-// interpreted as the address. For example "tcp://:80" is parsed to a network of
-// "tcp" and an address of ":80". The URI "unix:///tmp/my.sock" is parsed to a
+// The URI scheme is interpreted as the network, and the host (and port) are
+// interpreted as the address. For example, "tcp://:80" is parsed to a network
+// of "tcp" and an address of ":80", and "unix:///tmp/my.sock" is parsed to a
 // network of "unix" and an address of "/tmp/my.sock".
 //
-// If the URI doesn't have a scheme, "tcp://" is assumed by default. This means
-// common listen addresses like "localhost:8080" or "localhost:0" or ":8080"
-// should behave as expected.
+// If the URI doesn't have a scheme, "tcp://" is assumed by default, in an
+// attempt to keep basic compatibilty with common listen addresses like
+// "localhost:8080" or ":9090".
 func ParseURI(uri string) (network, address string, _ error) {
 	uri = strings.TrimSpace(uri)
 	if uri == "" {
@@ -47,7 +47,7 @@ func ParseURI(uri string) (network, address string, _ error) {
 }
 
 // ListenURI is a helper function that parses the provided URI via ParseURI, and
-// returns a [net.Listener] via [net.ListenConfig.Listen].
+// returns a [net.Listener] listening on the parsed network and address.
 func ListenURI(ctx context.Context, uri string) (net.Listener, error) {
 	network, address, err := ParseURI(uri)
 	if err != nil {

--- a/unixproxy/parse.go
+++ b/unixproxy/parse.go
@@ -1,0 +1,64 @@
+package unixproxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ParseURI parses the given URI to a network and address that can be passed to
+// e.g. [net.Listen].
+//
+// The URI's scheme is interpreted as the network, and the host (and port) are
+// interpreted as the address. For example "tcp://:80" is parsed to a network of
+// "tcp" and an address of ":80". The URI "unix:///tmp/my.sock" is parsed to a
+// network of "unix" and an address of "/tmp/my.sock".
+//
+// If the URI doesn't have a scheme, "tcp://" is assumed by default. This means
+// common listen addresses like "localhost:8080" or "localhost:0" or ":8080"
+// should behave as expected.
+func ParseURI(uri string) (network, address string, _ error) {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return "", "", fmt.Errorf("empty URI")
+	}
+
+	if !strings.Contains(uri, "://") {
+		uri = "tcp://" + uri
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", "", err
+	}
+
+	if u.Scheme == "" {
+		u.Scheme = "tcp"
+	}
+
+	if u.Host == "" && u.Path != "" {
+		u.Host = u.Path
+		u.Path = ""
+	}
+
+	return u.Scheme, u.Host, nil
+}
+
+// ListenURI is a helper function that parses the provided URI via ParseURI, and
+// returns a [net.Listener] via [net.ListenConfig.Listen].
+func ListenURI(ctx context.Context, uri string) (net.Listener, error) {
+	network, address, err := ParseURI(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	config := net.ListenConfig{}
+	listener, err := config.Listen(ctx, network, address)
+	if err != nil {
+		return nil, fmt.Errorf("listen: %w", err)
+	}
+
+	return listener, nil
+}

--- a/unixproxy/parse_test.go
+++ b/unixproxy/parse_test.go
@@ -1,0 +1,57 @@
+package unixproxy_test
+
+import (
+	"testing"
+
+	"github.com/peterbourgon/unixtransport/unixproxy"
+)
+
+func TestParseURI(t *testing.T) {
+	for _, testcase := range []struct {
+		uri              string
+		network, address string
+		err              bool
+	}{
+		// The package is designed to enable this kind of thing.
+		{uri: "tcp://:8080", network: "tcp", address: ":8080"},
+		{uri: "udp://:12345", network: "udp", address: ":12345"},
+		{uri: "unix:///tmp/my.sock", network: "unix", address: "/tmp/my.sock"},
+
+		// More normal stuff should work too, though.
+		{uri: ":8080", network: "tcp", address: ":8080"},
+		{uri: "localhost:8080", network: "tcp", address: "localhost:8080"},
+		{uri: "localhost:0", network: "tcp", address: "localhost:0"},
+		{uri: "localhost:", network: "tcp", address: "localhost:"},
+
+		// Verify clean parsing of typical URLs.
+		{uri: "example.com:443/path/part", network: "tcp", address: "example.com:443"},
+		{uri: "example.com:443?query=value", network: "tcp", address: "example.com:443"},
+		{uri: "example.com:443/path?and=query", network: "tcp", address: "example.com:443"},
+		{uri: "example.com:443/path?and=query#andfragment", network: "tcp", address: "example.com:443"},
+		{uri: "example.com:443/#justfragment", network: "tcp", address: "example.com:443"},
+
+		// Edge conditions.
+		{uri: "anything://:8080", network: "anything", address: ":8080"},
+		{uri: "file:///path/to/file.txt", network: "file", address: "/path/to/file.txt"},
+		{uri: "file://rel/path/index.txt", network: "file", address: "rel"},
+		{uri: "foo://bar", network: "foo", address: "bar"},
+		{uri: "unix://tmp/my.sock", network: "unix", address: "tmp"},               // no unix relative paths
+		{uri: "unix://tmp:8080/abc/my.sock", network: "unix", address: "tmp:8080"}, // likewise above
+		{uri: ":", network: "tcp", address: ":"},
+		{uri: "", err: true},
+	} {
+		t.Run(testcase.uri, func(t *testing.T) {
+			network, address, err := unixproxy.ParseURI(testcase.uri)
+			switch {
+			case testcase.err:
+				if err == nil {
+					t.Fatalf("want error, have none (network %q, address %q)", network, address)
+				}
+			case !testcase.err:
+				if network != testcase.network || address != testcase.address {
+					t.Fatalf("want %q %q, have %q %q", testcase.network, testcase.address, network, address)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
package unixproxy provides a reverse proxy (via package unixtransport) to Unix sockets on the local filesystem, allowing  local instances to be addressed as e.g. `nyc.1.unixproxy.localhost` (implicit port 80) instead of e.g. `localhost:8080`.