### PR TITLE
fix: don't use configured proxy for unix socket

### DIFF
--- a/register.go
+++ b/register.go
@@ -26,7 +26,7 @@ func Register(t *http.Transport) {
 
 	copy.Dial = nil    //lint:ignore SA1019 yes, it's deprecated, that's the point
 	copy.DialTLS = nil //lint:ignore SA1019 yes, it's deprecated, that's the point
-	copy.Proxy = nil   // never send unix socket conns to a proxy
+	copy.Proxy = nil   // Proxy doesn't support Unix sockets, so drop it
 
 	switch {
 	case copy.DialContext == nil && copy.DialTLSContext == nil:

--- a/register.go
+++ b/register.go
@@ -20,12 +20,13 @@ import (
 // so uses the same configuration: timeouts, TLS settings, and so on. Connection
 // pooling should also work as normal. One caveat: only the DialContext and
 // DialTLSContext dialers are respected; the Dial and DialTLS dialers are
-// explicitly removed and ignored.
+// explicitly removed and ignored. Any configured proxy is discarded.
 func Register(t *http.Transport) {
 	copy := t.Clone()
 
 	copy.Dial = nil    //lint:ignore SA1019 yes, it's deprecated, that's the point
 	copy.DialTLS = nil //lint:ignore SA1019 yes, it's deprecated, that's the point
+	copy.Proxy = nil   // never send unix socket conns to a proxy
 
 	switch {
 	case copy.DialContext == nil && copy.DialTLSContext == nil:

--- a/register.go
+++ b/register.go
@@ -20,7 +20,7 @@ import (
 // so uses the same configuration: timeouts, TLS settings, and so on. Connection
 // pooling should also work as normal. One caveat: only the DialContext and
 // DialTLSContext dialers are respected; the Dial and DialTLS dialers are
-// explicitly removed and ignored. Any configured proxy is discarded.
+// explicitly removed and ignored. Any configured Proxy is also discarded.
 func Register(t *http.Transport) {
 	copy := t.Clone()
 


### PR DESCRIPTION
Without this, this module won't work when `https_proxy` / `http_proxy` environment variables are set, as these are picked up by the default Go transport clients, and it erroneously tries to the send the connecting through the proxy.

We fix by explictly `nil`ing the `.Proxy` setting after cloning the `net.Transport`.