### PR TITLE
ListenURI, ListenURIConfig: os.Remove Unix domain sockets before trying to bind a listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can change it like this:
  addr := fs.String("addr", ":8080", "listen address")
  ...
 -http.ListenAndServe(*addr, nil)
-+ln, err := ListenURI(context.TODO(), *addr)
++ln, err := unixtransport.ListenURI(context.TODO(), *addr)
 +// handle err
 +http.Serve(ln, nil)
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ You can change it like this:
 Which lets you specify addrs like this:
 
 ```shell
-myserver -addr=unix:///tmp/mysocket
+myserver -addr=:8080                # equivalent to `tcp://:8080`
+myserver -addr=tcp://:8080          # listen on all interfaces, TCP port 8080
+myserver -addr=udp://0.0.0.0:12345  # listen on all IPv4 interfaces, UDP port 12345
+myserver -addr=unix:///tmp/mysocket # listen on Unix socket path /tmp/mysocket
 ```
 
 See e.g. [ParseURI][parseuri] and [ListenURI][listenuri] for more info.

--- a/uri_test.go
+++ b/uri_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"reflect"
 	"syscall"
@@ -151,4 +152,64 @@ func TestListenURIConfig(t *testing.T) {
 	if want, have := []networkAddress{{"unix", socket}}, seen; !reflect.DeepEqual(want, have) {
 		t.Errorf("seen: want %+v, have %+v", want, have)
 	}
+}
+
+func TestListenURIRemoveFailures(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("invalid URI", func(t *testing.T) {
+		uri := "unix:///"
+		if _, err := unixtransport.ListenURI(ctx, uri); err == nil {
+			t.Fatalf("ListenURI(%s): expected error, got none", uri)
+		}
+	})
+
+	t.Run("bad permission", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "dir")
+		if err := os.Mkdir(dir, 0755); err != nil {
+			t.Fatalf("os.Mkdir: %v", err)
+		}
+
+		sock := filepath.Join(dir, "sock")
+		if err := os.WriteFile(sock, []byte{}, 0644); err != nil {
+			t.Fatalf("os.WriteFile: %v", err)
+		}
+
+		// The only way to trigger an error on the os.Remove of the socket file
+		// in a unit test like this one, is to remove the write permission on
+		// the parent directory.
+		if err := os.Chmod(dir, 0555); err != nil {
+			t.Fatalf("os.Chmod(%s, 0555): %v", dir, err)
+		}
+		defer func() { // allow test cleanup to remove the TempDir
+			if err := os.Chmod(dir, 0755); err != nil {
+				t.Errorf("os.Chmod(%s, 0755): %v", dir, err)
+			}
+		}()
+
+		uri := "unix://" + sock
+		if _, err := unixtransport.ListenURI(ctx, uri); err == nil {
+			t.Fatalf("ListenURI(%s): expected error, got none", uri)
+		}
+	})
+
+	t.Run("socket is directory", func(t *testing.T) {
+		d := filepath.Join(t.TempDir(), "dir-as-sock")
+		if err := os.Mkdir(d, 0755); err != nil {
+			t.Fatalf("os.Mkdir: %v", err)
+		}
+		uri := "unix://" + d
+		if _, err := unixtransport.ListenURI(ctx, uri); err == nil {
+			t.Fatalf("ListenURI(%s): expected error, got none", uri)
+		}
+	})
+
+	t.Run("listen error", func(t *testing.T) {
+		uri := "doesnotexist://foo"
+		if _, err := unixtransport.ListenURI(ctx, uri); err == nil {
+			t.Fatalf("ListenURI(%s): expected error, got none", uri)
+		}
+	})
 }

--- a/uri_test.go
+++ b/uri_test.go
@@ -54,6 +54,8 @@ func TestParseURI(t *testing.T) {
 		{uri: ":", network: "tcp", address: ":"},
 		{uri: "", err: true},
 		{uri: "localhost:8080/a", network: "tcp", address: "localhost:8080"},
+		{uri: "://", err: true},
+		{uri: "tcp://", err: true},
 	} {
 		t.Run(testcase.uri, func(t *testing.T) {
 			network, address, err := unixtransport.ParseURI(testcase.uri)

--- a/uri_test.go
+++ b/uri_test.go
@@ -168,23 +168,23 @@ func TestListenURIRemoveFailures(t *testing.T) {
 
 	t.Run("bad permission", func(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "dir")
-		if err := os.Mkdir(dir, 0755); err != nil {
+		if err := os.Mkdir(dir, 0o755); err != nil {
 			t.Fatalf("os.Mkdir: %v", err)
 		}
 
 		sock := filepath.Join(dir, "sock")
-		if err := os.WriteFile(sock, []byte{}, 0644); err != nil {
+		if err := os.WriteFile(sock, []byte{}, 0o644); err != nil {
 			t.Fatalf("os.WriteFile: %v", err)
 		}
 
 		// The only way to trigger an error on the os.Remove of the socket file
 		// in a unit test like this one, is to remove the write permission on
 		// the parent directory.
-		if err := os.Chmod(dir, 0555); err != nil {
+		if err := os.Chmod(dir, 0o555); err != nil {
 			t.Fatalf("os.Chmod(%s, 0555): %v", dir, err)
 		}
 		defer func() { // allow test cleanup to remove the TempDir
-			if err := os.Chmod(dir, 0755); err != nil {
+			if err := os.Chmod(dir, 0o755); err != nil {
 				t.Errorf("os.Chmod(%s, 0755): %v", dir, err)
 			}
 		}()
@@ -197,7 +197,7 @@ func TestListenURIRemoveFailures(t *testing.T) {
 
 	t.Run("socket is directory", func(t *testing.T) {
 		d := filepath.Join(t.TempDir(), "dir-as-sock")
-		if err := os.Mkdir(d, 0755); err != nil {
+		if err := os.Mkdir(d, 0o755); err != nil {
 			t.Fatalf("os.Mkdir: %v", err)
 		}
 		uri := "unix://" + d

--- a/uri_test.go
+++ b/uri_test.go
@@ -200,9 +200,12 @@ func TestListenURIRemoveFailures(t *testing.T) {
 		if err := os.Mkdir(d, 0o755); err != nil {
 			t.Fatalf("os.Mkdir: %v", err)
 		}
+		if err := os.WriteFile(filepath.Join(d, "xxx"), []byte(`abc`), 0o644); err != nil {
+			t.Fatalf("os.WriteFile: %v", err)
+		}
 		uri := "unix://" + d
 		if _, err := unixtransport.ListenURI(ctx, uri); err == nil {
-			t.Fatalf("ListenURI(%s): expected error, got none", uri)
+			t.Errorf("ListenURI(%s): expected error, got none", uri)
 		}
 	})
 


### PR DESCRIPTION
Major change here is that ListenURI and ListenURIConfig will try to os.Remove any unix or unixpacket socket file before trying to net.Listen on it, ignoring os.IsNotExist errors.